### PR TITLE
security: add initial secret scan config

### DIFF
--- a/.github/workflows/secretscan.yml
+++ b/.github/workflows/secretscan.yml
@@ -1,0 +1,42 @@
+# This is a basic workflow to invoke a Trufflehog3 Secret Scan on your repo
+
+name: Secret Scan
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  # This workflow contains a single job called "scan"
+  scan:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+#      - name: Trofflehog Print Report for Testing
+#        run: echo $GITHUB_REPO && cat trufflehog_report.json
+#        env: 
+#          GITHUB_REPO: ${{ github.repository}}
+
+      - name: Trufflehog3 Secret Scan and Report Parser
+        uses: netlify/security-netlify-trufflehog3@v0.5
+        with:
+          trufflehog_report_file_path: 'trufflehog_report.json'
+          suppression_file_path: '.github/workflows/trufflehog3-files/suppressions-trufflehog3'
+          ignore_paths_file_path: '.github/workflows/trufflehog3-files/ignore-paths-trufflehog3'
+          create_github_issue: 'true'
+          create_slack_notification: 'false'
+          secret_scan_slack_webhook: ${{ secrets.SECRET_SCAN_SLACK_WEBHOOK }}
+          secret_scan_gh_access_token: ${{ secrets.GITHUB_TOKEN }}
+          github_repo_name: ${{ github.repository}}
+          github_server: ${{ github.server_url }}
+

--- a/.github/workflows/trufflehog3-files/suppressions-trufflehog3
+++ b/.github/workflows/trufflehog3-files/suppressions-trufflehog3
@@ -1,0 +1,2 @@
+343a2bf8c900e0e20959ef6a11378ee15f80c91d #example_org/example - removing key in commit
+kka1742068f7e436743d3e7ce0d1a54323f9c1e48c2dd582a5447d10425b8c53a2 - #netlify/trufflehog - testing


### PR DESCRIPTION
NOTICE: If this pull request does not apply to your repository, feel free to close this pull request. This is a pull request generated by [github-tools](https://github.com/netlify/github-tools/) to add an initial secret scan config. If your repo is critical or may contain secrets in code, you will want to use this. It is currently setup to scan all files it finds. See more documentation at https://github.com/netlify/security-netlify-trufflehog3
    It is best to start by running the scan by configuring to create_github_issue: false, and review the output in the Github Action console. Add false positive findings to the "suppressions-trufflehog3" file to ensure they wont be reported on the next scan, and change the "create_github_issue: true" value when you are ready to have issues created.
	