### PR TITLE
Add puppeteer dependency

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -211,7 +211,7 @@ bodyClass: landing
 			<h2>Submit your site</h2>
 			<p class="headline">We can’t wait to see it!</p>
 			<p class="form-error"></p>
-			<form class="submit-form" name="dusty-domains" method="POST" netlify-honeypot="bot-field" method="POST" netlify-data="true" action="/thanks">
+			<form class="submit-form" name="dusty-domains" method="POST" netlify-honeypot="bot-field" method="POST" data-netlify="true" action="/thanks">
 				<fieldset>
 					<label for="name">Your Name:</label>
 					<input type="text" name="name" id="name" required />

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cloudinary": "^1.23.0",
     "dotenv": "^10.0.0",
     "focus-visible": "^5.2.0",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "puppeteer-core": "^12.0.1"
   }
 }


### PR DESCRIPTION
Looks like puppeteer is required as a dependency for `aws-chrome-lambda`. When locally testing, it mentions that it was missing this part. [Source](https://github.com/alixaxel/chrome-aws-lambda#install)

I need to investigate off of a macOS device so do not merge yet 