### PR TITLE
Additional error handling for submission form

### DIFF
--- a/netlify/functions/upload.js
+++ b/netlify/functions/upload.js
@@ -1,33 +1,37 @@
-const cloudinary = require("cloudinary").v2;
-const Airtable = require("airtable");
+const cloudinary = require('cloudinary').v2;
+const Airtable = require('airtable');
 
 exports.handler = async (event) => {
   const data = JSON.parse(event.body);
   const AIRTABLE_BASE_ID = process.env.AIRTABLE_BASE_ID;
   const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
 
+  let screenshotURL;
+
   try {
-    // Step 1: upload to Cloudinary
+    if (data.screenshotBase64) {
+      // Step 1: upload to Cloudinary
 
-    cloudinary.config({
-      cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
-      api_key: process.env.CLOUDINARY_API_KEY,
-      api_secret: process.env.CLOUDINARY_API_SECRET,
-    });
+      cloudinary.config({
+        cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+        api_key: process.env.CLOUDINARY_API_KEY,
+        api_secret: process.env.CLOUDINARY_API_SECRET,
+      });
 
-    const cloudinaryResp = await cloudinary.uploader.upload(
-      data.screenshotBase64,
-      {
-        folder: "dusty-domains",
-      },
-      function (error, result) {
-        console.error(error);
-      }
-    );
+      const cloudinaryResp = await cloudinary.uploader.upload(
+        data.screenshotBase64,
+        {
+          folder: 'dusty-domains',
+        },
+        function (error, result) {
+          console.error(error);
+        },
+      );
 
-    const screenshotURL = cloudinaryResp.secure_url;
+      screenshotURL = cloudinaryResp.secure_url;
 
-    const { ["screenshotBase64"]: remove, ...rest } = data;
+      const { ['screenshotBase64']: remove, ...rest } = data;
+    }
 
     const submissionData = {
       ...rest,
@@ -37,30 +41,31 @@ exports.handler = async (event) => {
     // Step 2: upload to Airtable
 
     var base = new Airtable({ apiKey: AIRTABLE_API_KEY }).base(
-      AIRTABLE_BASE_ID
+      AIRTABLE_BASE_ID,
     );
-    base("Submissions").create(
+    base('Submissions').create(
       [
         {
           fields: submissionData,
         },
       ],
       function (err, records) {
+        console.log(records);
         if (err) {
           console.error(err);
           return;
         }
-      }
+      },
     );
 
     return {
       statusCode: 200,
-      body: "Successfully submitted",
+      body: 'Successfully submitted',
     };
   } catch (e) {
     return {
       statusCode: 500,
-      body: "Something went wrong while uploading your submission",
+      body: 'Something went wrong while uploading your submission',
     };
   }
 };

--- a/static/index.js
+++ b/static/index.js
@@ -15,31 +15,31 @@ submissionForm.onsubmit = async (e) => {
     'Years unused': parseInt(formData.get('site-date')),
   };
 
-  let screenshotBase64Data;
+  // let screenshotBase64Data;
 
-  try {
-    const screenshotRes = await fetch('/.netlify/functions/take-screenshot', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(submissionDetails.URL),
-    });
+  // try {
+  //   const screenshotRes = await fetch('/.netlify/functions/take-screenshot', {
+  //     method: 'POST',
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //     },
+  //     body: JSON.stringify(submissionDetails.URL),
+  //   });
 
-    screenshotBase64Data = await screenshotRes.json();
-  } catch (e) {
-    document.querySelector('.form-error').textContent =
-      "This site doesn't seem to be deployed on Netlify so we can't accept your submission 😢";
+  //   screenshotBase64Data = await screenshotRes.json();
+  // } catch (e) {
+  //   document.querySelector('.form-error').textContent =
+  //     "This site doesn't seem to be deployed on Netlify so we can't accept your submission 😢";
 
-    console.error(e);
-    formButton.disabled = false;
-  }
+  //   console.error(e);
+  //   formButton.disabled = false;
+  // }
 
-  // if we don't get a screenshot, log an error but don't fail
-  if (!screenshotBase64Data) {
-    screenshotBase64Data = false;
-    console.error('unable to generate a screenshot');
-  }
+  // // if we don't get a screenshot, log an error but don't fail
+  // if (!screenshotBase64Data) {
+  //   screenshotBase64Data = false;
+  //   console.error('unable to generate a screenshot');
+  // }
 
   try {
     const uploadRes = await fetch('/.netlify/functions/upload', {
@@ -49,15 +49,17 @@ submissionForm.onsubmit = async (e) => {
       },
       body: JSON.stringify({
         ...submissionDetails,
-        screenshotBase64: screenshotBase64Data,
+        // screenshotBase64: screenshotBase64Data,
       }),
     });
 
     if (uploadRes.ok) {
-      const url = new URL(submissionDetails.URL);
-      const age = 2021 - submissionDetails['Years unused'];
+      const { redirect } = await uploadRes.json();
 
-      window.location = window.location.href + `thanks/${url.host}/${age}`;
+      const nextURL = new URL(window.location.href);
+      nextURL.pathname = redirect;
+
+      window.location = nextURL;
     } else {
       throw new Error('Something went wrong while uploading your submission');
     }

--- a/static/index.js
+++ b/static/index.js
@@ -35,33 +35,37 @@ submissionForm.onsubmit = async (e) => {
     formButton.disabled = false;
   }
 
-  if (screenshotBase64Data) {
-    try {
-      const uploadRes = await fetch('/.netlify/functions/upload', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          ...submissionDetails,
-          screenshotBase64: screenshotBase64Data,
-        }),
-      });
+  // if we don't get a screenshot, log an error but don't fail
+  if (!screenshotBase64Data) {
+    screenshotBase64Data = false;
+    console.error('unable to generate a screenshot');
+  }
 
-      if (uploadRes.ok) {
-        const url = new URL(submissionDetails.URL);
-        const age = 2021 - submissionDetails['Years unused'];
+  try {
+    const uploadRes = await fetch('/.netlify/functions/upload', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ...submissionDetails,
+        screenshotBase64: screenshotBase64Data,
+      }),
+    });
 
-        window.location = window.location.href + `thanks/${url.host}/${age}`;
-      } else {
-        throw new Error('Something went wrong while uploading your submission');
-      }
-    } catch (e) {
-      document.querySelector('.form-error').textContent =
-        'Looks like something went a little bit haywire 🤔. Maybe try again!';
-      console.error(e);
-      formButton.disabled = false;
+    if (uploadRes.ok) {
+      const url = new URL(submissionDetails.URL);
+      const age = 2021 - submissionDetails['Years unused'];
+
+      window.location = window.location.href + `thanks/${url.host}/${age}`;
+    } else {
+      throw new Error('Something went wrong while uploading your submission');
     }
+  } catch (e) {
+    document.querySelector('.form-error').textContent =
+      'Looks like something went a little bit haywire 🤔. Maybe try again!';
+    console.error(e);
+    formButton.disabled = false;
   }
 };
 


### PR DESCRIPTION
The submission form seems to have a decent amount of intermittent failure, which I suspect is due to the screenshot taking pretty close to the function execution limit to complete, meaning we're probably getting a lot of timeouts. This tells the function to continue to submit if the screenshot is absent, which hopefully causes submissions to *always* succeed even if they're missing a screenshot.﻿
