### PR TITLE
Update showcase presentation

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -264,8 +264,8 @@ bodyClass: landing
 				{% for site in submissions %}
 				<li class="sites-item">
 					<a href={{ site.fields.URL}}>
-						<span class="site-title">{{ site.fields.URL}}
-							<span class="site-date">{{ site.fields["Years unused"] }}</span>
+						<span class="site-title">{{ site.fields.linktext }}
+							<span class="site-date">{{ site.fields.age }}</span>
 						</span>
 						<figure>
 							<img src="{{ site.fields.screenshot}}" alt="" />

--- a/netlify/plugins/airtable-feed/index.js
+++ b/netlify/plugins/airtable-feed/index.js
@@ -9,7 +9,23 @@ var dataDir;
 const fetchSubmissions = async() => {
     const response = await fetch(`https://api.airtable.com/v0/${AIRTABLE_BASE_ID}/Submissions?maxRecords=10000&view=Approved&api_key=${AIRTABLE_API_KEY}`);
     const data = await response.json();
-    return data.records;
+    return data.records.map(record=>{
+        record.fields.linktext=new URL(record.fields.URL).hostname;
+        const age = 2021-record.fields['Years unused'];
+        if (age < 1) {
+            record.fields.age = 'fresh';
+        }
+        else if (age == 1) {
+            record.fields.age = '1 year dusty';
+        }
+        else if (age > 1) {
+            record.fields.age = `${age} years dusty`;
+        }
+        else {
+            record.fields.age = '';
+        }
+        return record
+    });
 }
 
 

--- a/thanks.njk
+++ b/thanks.njk
@@ -51,7 +51,15 @@ permalink:
 			<li class="sites-item">
 				<a href="https://{{ eleventy.serverless.path.site }}">
 					<span class="site-title">{{ eleventy.serverless.path.site }}
-						<span class="site-date">{{ eleventy.serverless.path.age }} years dusty</span>
+						{% if eleventy.serverless.path.age > 1 %}
+							<span class="site-date">{{ eleventy.serverless.path.age }} years dusty</span>
+						{% elif eleventy.serverless.path.age == 1 %}
+							<span class="site-date">{{ eleventy.serverless.path.age }} year dusty</span>
+						{% elif eleventy.serverless.path.age < 1 %}
+							<span class="site-date">fresh</span>
+						{% else %}
+							<span class="site-date"></span>
+						{% endif %}
 					</span>
 					<figure>
 						<img src="DUSTY_DOMAINS_SCREENSHOT_URL" alt="screenshot of website" />


### PR DESCRIPTION
Closes #49

This PR makes some adjustments to each site in the showcase:
- Only shows the domain name (without `https://`)
- Shows proper "3 years dusty" labels ("fresh" if < 1year old and left blank if unknown)
- Also updates the featured link on the /thanks page to match functionality

![image](https://user-images.githubusercontent.com/871315/144654950-1e208987-2b61-4f1a-90a8-de7f3f4b0e19.png)
